### PR TITLE
添加英文 README 与剩余硬编码文案本地化 / Add an English README and localize the remaining hardcoded text

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,72 @@
+<div align="center">
+  <img src="./app/src/main/ic_launcher-round.png" alt="Phoenix" width="128" height="128">
+  <h1>Phoenix (不死鸟)</h1>
+
+[![GitHub release](https://img.shields.io/github/v/release/h3110w0r1d-y/Phoenix)](https://github.com/h3110w0r1d-y/Phoenix/releases)
+[![CI/CD](https://github.com/h3110w0r1d-y/Phoenix/actions/workflows/release.yml/badge.svg)](https://github.com/h3110w0r1d-y/Phoenix/actions/workflows/release.yml)
+![Android](https://img.shields.io/badge/Android-8.0%2B-blue)
+![License](https://img.shields.io/github/license/h3110w0r1d-y/Phoenix)
+![GitHub stars](https://img.shields.io/github/stars/h3110w0r1d-y/Phoenix?style=social)
+</div>
+
+---
+
+[简体中文](README.md)
+
+## About
+
+Based on Xposed. It hooks the process creation functions of the system framework and
+changes the MaxOomAdj of a process to keep app processes alive.
+
+Android 8+ is supported in theory. Hook location:
+[Hook.kt](./app/src/main/java/com/h3110w0r1d/phoenix/hook/Hook.kt). It has only been
+tested on Android 15~16, so use it with caution on other versions.
+
+## Download
+
+  - [Latest Release](https://github.com/h3110w0r1d-y/Phoenix/releases/latest)
+
+## Usage
+
+  - Open LSPosed, enable the module, select `System Framework` only, and reboot the
+    system for the module to take effect
+  - Open the module and check the apps you want to keep alive (Android 10+ takes effect
+    immediately, without restarting the system or the app; below Android 10 the app has
+    to be restarted)
+
+## Screenshots
+
+<details>
+    <summary>Click to expand the screenshots</summary>
+    <img src="img/home.png" width="300">
+    <img src="img/app.png" width="300">
+    <img src="img/setting.png" width="300">
+</details>
+
+## Language
+
+Simplified Chinese is the default language of the app: it is what Phoenix shows unless
+another available language matches the device. English is available as a translation.
+
+To read the app in English, use the per-app language preference of Android 13+:
+**Settings › Apps › Phoenix › Language**. On earlier versions the app follows the
+system language.
+
+## Roadmap
+
+  - [x] Configure the default MaxAdj
+  - [x] Configure a different MaxAdj per app
+  - [x] Support for enabling Persistent
+  - [x] Activity keep-alive (Android 11+)
+  - [x] Service keep-alive (TargetApi < 34)
+
+Suggestions and problems are welcome: open an Issue, or join the QQ group 1083682874.
+
+## Donate
+
+<img src="img/wechat.png" width="300">
+<img src="img/alipay.jpg" width="300">
+
+## ❤️Sponsors
+
+- [Jie0746](https://github.com/Jie0746)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 
 ---
 
+[English](README.en.md)
+
 ## 项目简介
 
 基于 Xposed，Hook 系统框架的进程创建函数，修改进程的 MaxOomAdj 实现应用进程保活。

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.Phoenix">
         <activity

--- a/app/src/main/java/com/h3110w0r1d/phoenix/ui/screen/SettingScreen.kt
+++ b/app/src/main/java/com/h3110w0r1d/phoenix/ui/screen/SettingScreen.kt
@@ -273,13 +273,22 @@ fun SettingScreen() {
                     }
                     lastTimeStamp = System.currentTimeMillis()
                     if (clickCount >= maxClickCount) {
-                        mToast = Toast.makeText(context, "啥都木有", Toast.LENGTH_SHORT)
+                        mToast =
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.nothing_here),
+                                Toast.LENGTH_SHORT,
+                            )
                         mToast?.show()
                     } else {
                         mToast =
                             Toast.makeText(
                                 context,
-                                "Click $clickCount times",
+                                context.resources.getQuantityString(
+                                    R.plurals.click_count_toast,
+                                    clickCount,
+                                    clickCount,
+                                ),
                                 Toast.LENGTH_SHORT,
                             )
                         mToast?.show()

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -83,4 +83,9 @@
     <string name="home_screen">Home</string>
     <string name="setting_screen">Setting</string>
     <string name="app_screen">App</string>
+    <string name="nothing_here">Nothing here</string>
+    <plurals name="click_count_toast">
+        <item quantity="one">Click %1$d time</item>
+        <item quantity="other">Click %1$d times</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,4 +83,8 @@
     <string name="home_screen">主页</string>
     <string name="setting_screen">设置</string>
     <string name="app_screen">应用</string>
+    <string name="nothing_here">啥都木有</string>
+    <plurals name="click_count_toast">
+        <item quantity="other">Click %1$d times</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="zh-CN" />
+    <locale android:name="en" />
+</locale-config>


### PR DESCRIPTION
## 简介

不死鸟的界面文案已经有完整的英文翻译（`res/values-en/strings.xml`），但文档只有简体中文，并且版本号彩蛋的两个 Toast 仍然硬编码在 `SettingScreen.kt` 里，英文环境下会看到中文。本 PR 补上这两处，同时**不改变原有语言的地位**。

- `README.en.md` 是 `README.md` 的英文翻译；`README.md` 仍是原始文档，唯一的改动是添加了一行指向英文版的链接
- 彩蛋文案提取到资源：`res/values` 逐字保留 `啥都木有`，中文环境下的显示结果与改动前完全一致；`res/values-en` 存放英文翻译
- 点击计数改用 `<plurals>`，这样英文的单复数才正确（`Click 1 time`）；`res/values` 逐字保留原来的 `Click %1$d times`

## 语言选择

应用跟随系统语言。`res/xml/locales_config.xml` 声明 `zh-CN` 和 `en`，由 `android:localeConfig` 引用，从而启用 Android 13+ 的「按应用设置语言」（设置 › 应用 › 不死鸟 › 语言）。`minSdk` 是 26，API 33 以下会忽略该属性，行为与改动前一致，仍然跟随系统语言。没有在应用内另做一套语言开关，这项偏好本来就属于系统。

## 其他说明

- Hook 侧的通知文案（`Keep Alive`、`Running`）没有改动：它运行在被 Hook 的进程里，拿不到模块的资源
- 语言环境既不是中文也不是英文时（例如 pt-BR），会回退到 `values/`，也就是中文，这是有意的
- 「画饼」一节在英文版里译作 Roadmap

## 验证

- `:app:assembleDebug` 通过（本机只有 JDK 17，因此本地把 `compileOptions` / `jvmTarget` 临时改为 17 来编译，这个改动**没有**包含在提交里）
- 两个资源文件的键一一对应（各 86 个），格式化占位符逐条匹配，没有缺失或多余的键
- 生成的 APK 同时包含 `zh-rCN` 和 `en` 两种语言配置，清单里写入了 `android:localeConfig`，资源表里能查到 `啥都木有` / `Nothing here` / `Click %1$d time(s)`
- 已安装到 Galaxy S20 FE（One UI，Android 13，arm64-v8a）确认可正常安装
- 我的设备系统语言是 pt-BR，按预期回退到中文；英文需在「设置 › 应用 › 不死鸟 › 语言」中选择
- 没有启用模块并重启系统测试保活功能：本 PR 不触及 Hook 逻辑

---

## Summary

Phoenix already ships a complete English translation in `res/values-en/strings.xml`, but the documentation was Simplified Chinese only, and the two toasts of the version easter egg were still hardcoded in `SettingScreen.kt`, so an English device saw Chinese there. This PR closes both gaps **without displacing the original language**.

- `README.en.md` is an English translation of `README.md`. `README.md` remains the original document and its only change is one line linking to the translation
- The easter egg text moved into resources: `res/values` keeps `啥都木有` verbatim, so a device in Chinese sees exactly what it saw before, and `res/values-en` carries the translation
- The click counter became a `<plurals>`, so the English text agrees in number (`Click 1 time`); `res/values` keeps the previous `Click %1$d times` verbatim

## Language selection

The app follows the system language. `res/xml/locales_config.xml` declares `zh-CN` and `en` and is referenced by `android:localeConfig`, which enables the per-app language preference of Android 13+ (Settings › Apps › Phoenix › Language). `minSdk` is 26, so below API 33 the attribute is ignored and the behaviour is unchanged — the app keeps following the system language. No in-app language picker was added: the system already owns that preference.

## Notes

- The notification text on the hook side (`Keep Alive`, `Running`) is untouched: it runs inside the hooked process, where the module resources are not available
- A locale that is neither Chinese nor English (pt-BR, for example) falls back to `values/`, that is, to Chinese. This is deliberate
- The 画饼 section is rendered as "Roadmap" in the English README

## Verification

- `:app:assembleDebug` passes (this machine only has JDK 17, so `compileOptions` / `jvmTarget` were temporarily lowered to 17 locally to compile; that change is **not** part of the commit)
- Both resource files carry the same keys (86 each) and the format placeholders match key by key, with no missing or extra key
- The resulting APK carries both the `zh-rCN` and `en` configurations, the manifest carries `android:localeConfig`, and the resource table contains `啥都木有` / `Nothing here` / `Click %1$d time(s)`
- Installed on a Galaxy S20 FE (One UI, Android 13, arm64-v8a) to confirm it installs cleanly
- My device runs in pt-BR, which falls back to Chinese as expected; English is selected through Settings › Apps › Phoenix › Language
- I did not enable the module and reboot to test the keep-alive behaviour: this PR does not touch the hook logic
